### PR TITLE
make RequestStreamHandler work with serverless offline

### DIFF
--- a/libs/java-invoke-local/src/main/groovy/serverless/jvm/plugin/InvokeRequest.groovy
+++ b/libs/java-invoke-local/src/main/groovy/serverless/jvm/plugin/InvokeRequest.groovy
@@ -1,6 +1,7 @@
 package serverless.jvm.plugin
 
 import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
@@ -34,6 +35,9 @@ class InvokeRequest {
 
     if (jsonOutput) {
       try {
+        if (null != result && result.getClass().isAssignableFrom(ByteArrayOutputStream.class)) {
+          result = new JsonSlurper().parse(((ByteArrayOutputStream)result).toByteArray())
+        }
         if (serverlessOffline) {
           return JsonOutput.toJson(['__offline_payload__': result])
         } else {
@@ -51,6 +55,7 @@ class InvokeRequest {
   @Memoized
   static LambdaFunction load(long lastModified, File artifact, String handler) {
     final classLoader = LambdaClassLoader.getClassLoader(artifact)
+    Thread.currentThread().setContextClassLoader(classLoader)
     final lambda = LambdaFunction.create(handler, classLoader)
     return lambda
   }

--- a/libs/java-invoke-local/src/main/groovy/serverless/jvm/plugin/LocalInvocation.groovy
+++ b/libs/java-invoke-local/src/main/groovy/serverless/jvm/plugin/LocalInvocation.groovy
@@ -11,11 +11,21 @@ class LocalInvocation {
   static final ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
   static invoke(LambdaFunction lambda, String input, String functionName = null) {
+    def event, context, exception
+    try {
+      final parsed = new JsonSlurper().parseText(input)
+      if (parsed.event && parsed.context) {
+        event = parsed.event
+        context = parsed.context
+      }
+    } catch (e) {
+      exception = e
+    }
 
     if (RequestStreamHandler.isAssignableFrom(lambda.clazz)) {
-      def inputStream = new ByteArrayInputStream(input.getBytes())
+      def inputStream = new ByteArrayInputStream(null != event ? JsonOutput.toJson(event).getBytes() : input.getBytes())
       def outputStream = new ByteArrayOutputStream()
-      lambda.instance."${lambda.method}"(inputStream, outputStream, mockContext(lambda))
+      lambda.instance."${lambda.method}"(inputStream, outputStream, null != context ? newContext(context) : mockContext(lambda))
       return outputStream
     } else {
       if (lambda.parameterType.isPrimitive() || isWrapperType(lambda.parameterType) || lambda.parameterType == String) {
@@ -30,14 +40,7 @@ class LocalInvocation {
           }
         }
 
-        def event, context
-        try {
-          final parsed = new JsonSlurper().parseText(input)
-          if (parsed.event && parsed.context) {
-            event = parsed.event
-            context = parsed.context
-          }
-        } catch (e) {
+        if (null != exception) {
           throw new Exception("Unable to convert input \"${input}\" to ${lambda.parameterType.name}")
         }
         if (event && context) {


### PR DESCRIPTION
The java runner in serverless-offline sends the requested data in the following format:
https://github.com/dherault/serverless-offline/blob/2c7e01b15bd8e020ff253692be12140ac3ed7aee/src/lambda/handler-runner/java-runner/JavaRunner.js#L63
This pr will make RequestStreamHandler also accept this format of data.

We also met a problem when we tried to use serverless offline to test an AWS lambda function written in Java with Spring Cloud Function framework.
![image](https://user-images.githubusercontent.com/12808025/158899757-bb1ac012-ad24-49f3-a4bf-4e9d27958c9b.png)

But the same function works properly when we tried to invoke it using "serverless invoke local". So we took a look at both source codes. We found the serverless project had this line for reflecting the class from the jar file.
https://github.com/serverless/serverless/blob/bf79934e9b43a0b2e8613ee29f9430fa22c41481/lib/plugins/aws/invoke-local/runtime-wrappers/java/src/main/java/com/serverless/InvokeBridge.java#L67

After we added this line into java-invoke-local, the problem is resolved.
![image](https://user-images.githubusercontent.com/12808025/158901296-63ab9700-4b37-4aae-8801-0c09f3c317fc.png)
