### PR TITLE
Upgrade jackson version

### DIFF
--- a/libs/java-invoke-local/build.gradle
+++ b/libs/java-invoke-local/build.gradle
@@ -12,7 +12,7 @@ dependencies {
   implementation 'info.picocli:picocli:4.1.1'
   implementation 'org.codehaus.groovy:groovy-all:2.5.9'
   implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
 }
 


### PR DESCRIPTION
I am using a higher version jackson library in my serverless project but I am getting NoSuchMethodError because this package uses an older one that doesn't have some jackson new features. 