### PR TITLE
Quarkus request handler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@
 - [kotlin-simple](templates/kotlin-simple)
 - [kotlin-spark-monolith](templates/kotlin-spark-monolith)
 - [scala-simple](templates/scala-simple)
+
+### Fork modifications
+
+ - Quarkus request handler execution 
+ - Changes from https://github.com/bytekast/serverless-toolkit/pull/1

--- a/libs/java-invoke-local/build.gradle
+++ b/libs/java-invoke-local/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
   implementation 'info.picocli:picocli:4.1.1'
-  implementation 'org.codehaus.groovy:groovy-all:2.5.9'
+  implementation 'org.codehaus.groovy:groovy-all:2.5.14'
   implementation 'com.amazonaws:aws-lambda-java-core:1.2.0'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'

--- a/libs/java-invoke-local/src/main/groovy/serverless/jvm/plugin/LambdaFunction.groovy
+++ b/libs/java-invoke-local/src/main/groovy/serverless/jvm/plugin/LambdaFunction.groovy
@@ -11,6 +11,7 @@ class LambdaFunction {
   Class returnType
   Class parameterType
   Boolean hasContext
+  Boolean hasOutput
 
   static LambdaFunction create(String handler, ClassLoader classLoader) {
     def (String className, String methodName) = handler.tokenize('::')
@@ -32,19 +33,26 @@ class LambdaFunction {
       function.method = method.name
       function.returnType = method.returnType
       final parameterTypes = method.nativeParameterTypes
-      if (parameterTypes.size() < 1 || parameterTypes.size() > 2) {
-        throw new Exception("Handler method must have 1 or 2 parameters")
+      if (parameterTypes.size() < 1 || parameterTypes.size() > 3) {
+        throw new Exception("Handler method must have 1 to 3 parameters")
       }
 
       def first = parameterTypes?.size() > 0 ? parameterTypes[0] : null
       def second = parameterTypes?.size() > 1 ? parameterTypes[1] : null
+      def third = parameterTypes?.size() > 2 ? parameterTypes[2] : null
       function.parameterType = first
-      if (second != null && second != Context) {
-        throw new Exception("The second handler method parameter must be of type com.amazonaws.services.lambda.runtime.Context")
+      if ((second != null && third == null && second != Context) || (third != null && third != Context)) {
+        throw new Exception("The second or third handler method parameter must be of type com.amazonaws.services.lambda.runtime.Context")
       }
 
-      if (second) {
+      if (second || third) {
         function.hasContext = true
+      }
+      if (third) {
+        if (second != OutputStream || third != Context) {
+          throw new Exception("If third third handler method parameter is com.amazonaws.services.lambda.runtime.Context, second must be java.io.OutputStream")
+        }
+        function.hasOutput = true
       }
     } else {
       if (!(RequestHandler.isAssignableFrom(clazz) || RequestStreamHandler.isAssignableFrom(clazz))) {
@@ -56,6 +64,7 @@ class LambdaFunction {
       function.returnType = method?.returnType
       function.parameterType = method?.nativeParameterTypes?.first()
       function.hasContext = true
+      function.hasOutput = false
     }
 
     function.instance = clazz.newInstance([].toArray())


### PR DESCRIPTION
The generic request handler of Quarkus (`io.quarkus.amazon.lambda.runtime.QuarkusStreamHandler::handleRequest`) accepts 3 parameters instead of 2. Accordingly the execution breaks down. This PR is just a quick fix proposal, demonstrating the issue.

These changes also include modifications for #1. 